### PR TITLE
Migrate from `pykalman` to `pykalman-bardo`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ torch = "^1.11.0"
 pytorch-lightning = "^1.6.4"
 notebook = "^6.4.12"
 einops = "^0.4.1"
-pykalman = "^0.9.5"
+pykalman-bardo = "^0.9.6"
 hydra-core = "^1.2.0"
 plotnine = "^0.9.0"
 qpsolvers = {extras = ["starter_solvers"], version = "^2.2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ torch = "^1.11.0"
 pytorch-lightning = "^1.6.4"
 notebook = "^6.4.12"
 einops = "^0.4.1"
-pykalman-bardo = "^0.9.6"
+pykalman-bardo = "^0.9.7"
 hydra-core = "^1.2.0"
 plotnine = "^0.9.0"
 qpsolvers = {extras = ["starter_solvers"], version = "^2.2.0"}


### PR DESCRIPTION
# Description:
Consider migration from `pykalman` to `pykalman-bardo`, as [pykalman](https://github.com/pykalman/pykalman) project is no longer maintained. There were some issues that were fixed, see: https://github.com/pybardo/pykalman/blob/v0.9.7/CHANGELOG

I'm going to maintain [pykalman-bardo](https://github.com/pybardo/pykalman), react to issues, and fix bugs. For now the API is the same as in the initial package, but it might evolve in time.

I hope you will find it useful for your project!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
